### PR TITLE
Implemented method setTitle

### DIFF
--- a/src/main/scala/introprog/PixelWindow.scala
+++ b/src/main/scala/introprog/PixelWindow.scala
@@ -224,6 +224,9 @@ class PixelWindow(
     Swing.await { new java.awt.Color(canvas.img.getRGB(x, y)) }
   }
 
+  /** Set the PixelWindow frame title. */
+  def setTitle(title: String): Unit = frame.setTitle(title)
+  
   /** Show the window. Has no effect if the window is already visible. */
   def show(): Unit = Swing { frame.setVisible(true) }
 


### PR DESCRIPTION
Added setTitle to PixelWindow. Updates PixelWindow frame title to `title: String` using `JFrame.setTitle(string title);`